### PR TITLE
Migration of canvas test helpers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: canvas_test_helpers
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v1.5.3
+        with:
+          flutter-version: '2.5.x'
+
+
+      - name: Install Dependencies
+        run: flutter packages get
+
+      - name: Format
+        run: flutter format --set-exit-if-changed lib
+
+      - name: Analyze
+        run: flutter analyze lib

--- a/.metadata
+++ b/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: 4cc385b4b84ac2f816d939a49ea1f328c4e0b48e
+  channel: beta
+
+project_type: package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# CHANGELOG
+
+## 0.0.1
+ - Initial release containing classes to help testing applications using the `Canvas`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # CHANGELOG
 
-## 0.0.1
+## 0.1.0
  - Initial release containing classes to help testing applications using the `Canvas`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canvas test helpers
 
-[MockCanvas] is a utility class for writing tests. It supports the same API
+[MockCanvas] is a utility class for writing tests for canvas operations. It supports the same API
 as the regular [Canvas] class from dart:ui (in theory; any missing commands
 can be added as the need arises). In addition, this class is also a
 [Matcher], allowing it to be used in `expect()` calls as can be seen in the

--- a/README.md
+++ b/README.md
@@ -1,39 +1,38 @@
-<!-- 
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# Canvas test helpers
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+[MockCanvas] is a utility class for writing tests. It supports the same API
+as the regular [Canvas] class from dart:ui (in theory; any missing commands
+can be added as the need arises). In addition, this class is also a
+[Matcher], allowing it to be used in `expect()` calls as can be seen in the
+example below.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-library-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/developing-packages). 
--->
+Two mock canvases will match only if they have the same number of commands,
+and if each pair of corresponding commands matches.
 
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+Multiple transform commands (`translate()`, `scale()`, `rotate()` and
+`transform()`) that are issued in a row are always joined into a single
+combined transform. Thus, for example, calling `translate(10, 10)` and
+then `translate(30, -10)` will match a single call `translate(40, 0)`.
 
-## Features
+Some commands can be partially specified. For example, in `drawLine()` and
+`drawRect()` the `paint` argument is optional. If provided, it will be
+checked against the actual Paint used, but if omitted, the match will still
+succeed.
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+Commands that involve numeric components (i.e. coordinates, dimensions,
+etc) will be matched approximately, with the default absolute tolerance of
+1e-10.
 
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
-
-## Usage
-
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder. 
+## Example Usage
 
 ```dart
-const like = 'sample';
+final canvas = MockCanvas();
+// ... draw something on the canvas
+// then check that the commands issued were the ones that you'd expect:
+expect(
+  canvas,
+  MockCanvas()
+    ..translate(10, 10)
+    ..drawRect(const Rect.fromLTWH(0, 0, 100, 100)),
+);
 ```
-
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to 
-contribute to the package, how to file issues, what response they can expect 
-from the package authors, and more.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/lib/canvas_test_helpers.dart
+++ b/lib/canvas_test_helpers.dart
@@ -1,7 +1,10 @@
-library canvas_test_helpers;
-
-/// A Calculator.
-class Calculator {
-  /// Returns [value] plus 1.
-  int addOne(int value) => value + 1;
-}
+export 'src/assertion_mode.dart';
+export 'src/canvas_commands/cliprect_command.dart';
+export 'src/canvas_commands/command.dart';
+export 'src/canvas_commands/image_command.dart';
+export 'src/canvas_commands/line_command.dart';
+export 'src/canvas_commands/paragraph_command.dart';
+export 'src/canvas_commands/rect_command.dart';
+export 'src/canvas_commands/rrect_command.dart';
+export 'src/canvas_commands/transform_command.dart';
+export 'src/mock_canvas.dart';

--- a/lib/canvas_test_helpers.dart
+++ b/lib/canvas_test_helpers.dart
@@ -1,0 +1,7 @@
+library canvas_test_helpers;
+
+/// A Calculator.
+class Calculator {
+  /// Returns [value] plus 1.
+  int addOne(int value) => value + 1;
+}

--- a/lib/src/assertion_mode.dart
+++ b/lib/src/assertion_mode.dart
@@ -1,0 +1,13 @@
+/// Defines how MockCanvas#matches behaves.
+enum AssertionMode {
+  /// Actual and expected must match exactly in nature and order.
+  ///
+  /// This is implemented by MockCanvas#matchExactly.
+  matchExactly,
+
+  /// All elements on expect must match to at least one element on actual,
+  /// regardless of order.
+  ///
+  /// This is implemented by MockCanvas#containsAnyOrder.
+  containsAnyOrder,
+}

--- a/lib/src/canvas_commands/cliprect_command.dart
+++ b/lib/src/canvas_commands/cliprect_command.dart
@@ -1,0 +1,23 @@
+import 'dart:ui';
+import 'command.dart';
+
+/// canvas.clipRect()
+class ClipRectCommand extends CanvasCommand {
+  ClipRectCommand(this.clipRect, this.clipOp, this.doAntiAlias);
+
+  final Rect clipRect;
+  final ClipOp clipOp;
+  final bool doAntiAlias;
+
+  @override
+  bool equals(ClipRectCommand other) {
+    return eq(clipRect, other.clipRect) &&
+        clipOp == other.clipOp &&
+        doAntiAlias == other.doAntiAlias;
+  }
+
+  @override
+  String toString() {
+    return 'clipRect(${repr(clipRect)}, clipOp=$clipOp, doAntiAlias=$doAntiAlias)';
+  }
+}

--- a/lib/src/canvas_commands/command.dart
+++ b/lib/src/canvas_commands/command.dart
@@ -1,0 +1,107 @@
+import 'dart:ui';
+import '../mock_canvas.dart';
+
+/// This class encapsulates a single command that was issued to a [MockCanvas].
+/// Most methods of [MockCanvas] will use a dedicated class derived from
+/// [CanvasCommand] to store all the arguments and then match them against
+/// the expected values.
+///
+/// Each subclass is expected to implement two methods:
+///   - `equals()`, which compares the current object against another instance
+///     of the same class; and
+///   - `toString()`, which is used when printing error messages in case of a
+///     mismatch.
+///
+/// Use helper function `eq()` to implement the first method, and `repr()` to
+/// implement the second.
+abstract class CanvasCommand {
+  double tolerance = 1e-10;
+
+  /// Return true if this command is equal to [other], up to the
+  /// given absolute [tolerance]. The argument [other] is guaranteed
+  /// to have the same type as the current command.
+  bool equals(covariant CanvasCommand other);
+
+  /// Helper function to check the equality of any two objects.
+  bool eq(dynamic a, dynamic b) {
+    if (a == null || b == null) {
+      return true;
+    }
+    if (a is num && b is num) {
+      return (a - b).abs() < tolerance;
+    }
+    if (a is Offset && b is Offset) {
+      return eq(a.dx, b.dx) && eq(a.dy, b.dy);
+    }
+    if (a is List && b is List) {
+      return a.length == b.length &&
+          Iterable<int>.generate(a.length).every((i) => eq(a[i], b[i]));
+    }
+    if (a is Rect && b is Rect) {
+      return eq(_rectAsList(a), _rectAsList(b));
+    }
+    if (a is RRect && b is RRect) {
+      return eq(_rrectAsList(a), _rrectAsList(b));
+    }
+    if (a is Paint && b is Paint) {
+      return eq(_paintAsList(a), _paintAsList(b));
+    }
+    return a == b;
+  }
+
+  /// Helper function to generate string representations of various
+  /// components of a command.
+  String repr(dynamic a) {
+    if (a is num) {
+      // A more compact stringification for a floating-point [a]: it avoids
+      // printing ".0" at the end of round floating numbers.
+      return (a == a.toInt()) ? a.toInt().toString() : a.toString();
+    }
+    if (a is Offset) {
+      return 'Offset(${repr(a.dx)}, ${repr(a.dy)})';
+    }
+    if (a is List) {
+      return a.map(repr).join(', ');
+    }
+    if (a is Rect) {
+      return 'Rect(${repr(_rectAsList(a))})';
+    }
+    if (a is RRect) {
+      return 'RRect(${repr(_rrectAsList(a))})';
+    }
+    if (a is Paint) {
+      return 'Paint(${repr(_paintAsList(a))})';
+    }
+    return a.toString();
+  }
+
+  List<double> _rectAsList(Rect rect) {
+    return [rect.left, rect.top, rect.right, rect.bottom];
+  }
+
+  List<double> _rrectAsList(RRect rect) {
+    return [
+      rect.left,
+      rect.top,
+      rect.right,
+      rect.bottom,
+      rect.tlRadiusX,
+      rect.tlRadiusY,
+      rect.trRadiusX,
+      rect.trRadiusY,
+      rect.blRadiusX,
+      rect.blRadiusY,
+      rect.brRadiusX,
+      rect.brRadiusY,
+    ];
+  }
+
+  List _paintAsList(Paint paint) {
+    return <dynamic>[
+      paint.color,
+      paint.blendMode,
+      paint.style,
+      paint.strokeWidth,
+    ];
+  }
+}

--- a/lib/src/canvas_commands/image_command.dart
+++ b/lib/src/canvas_commands/image_command.dart
@@ -1,0 +1,20 @@
+import 'dart:ui';
+import 'command.dart';
+
+/// canvas.drawImage()
+class ImageCommand extends CanvasCommand {
+  final Offset offset;
+  final Paint? paint;
+
+  ImageCommand(this.offset, this.paint);
+
+  @override
+  bool equals(ImageCommand other) {
+    return eq(offset, other.offset) && eq(paint, other.paint);
+  }
+
+  @override
+  String toString() {
+    return 'drawImage(image, ${repr(offset)}, ${repr(paint)})';
+  }
+}

--- a/lib/src/canvas_commands/line_command.dart
+++ b/lib/src/canvas_commands/line_command.dart
@@ -1,0 +1,20 @@
+import 'dart:ui';
+import 'command.dart';
+
+/// canvas.drawLine()
+class LineCommand extends CanvasCommand {
+  LineCommand(this.p1, this.p2, this.paint);
+  final Offset p1;
+  final Offset p2;
+  final Paint? paint;
+
+  @override
+  bool equals(LineCommand other) {
+    return eq(p1, other.p1) && eq(p2, other.p2) && eq(paint, other.paint);
+  }
+
+  @override
+  String toString() {
+    return 'drawLine(${repr(p1)}, ${repr(p2)}, ${repr(paint)})';
+  }
+}

--- a/lib/src/canvas_commands/paragraph_command.dart
+++ b/lib/src/canvas_commands/paragraph_command.dart
@@ -1,0 +1,16 @@
+import 'dart:ui';
+import 'command.dart';
+
+/// canvas.drawParagraph()
+class ParagraphCommand extends CanvasCommand {
+  ParagraphCommand(this.offset);
+  final Offset offset;
+
+  @override
+  bool equals(ParagraphCommand other) => eq(offset, other.offset);
+
+  @override
+  String toString() {
+    return 'drawParagraph(${repr(offset)})';
+  }
+}

--- a/lib/src/canvas_commands/rect_command.dart
+++ b/lib/src/canvas_commands/rect_command.dart
@@ -1,0 +1,19 @@
+import 'dart:ui';
+import 'command.dart';
+
+/// canvas.drawRect()
+class RectCommand extends CanvasCommand {
+  RectCommand(this.rect, this.paint);
+  final Rect rect;
+  final Paint? paint;
+
+  @override
+  bool equals(RectCommand other) {
+    return eq(rect, other.rect) && eq(paint, other.paint);
+  }
+
+  @override
+  String toString() {
+    return 'drawRect(${repr(rect)}, ${repr(paint)})';
+  }
+}

--- a/lib/src/canvas_commands/rrect_command.dart
+++ b/lib/src/canvas_commands/rrect_command.dart
@@ -1,0 +1,19 @@
+import 'dart:ui';
+import 'command.dart';
+
+/// canvas.drawRRect()
+class RRectCommand extends CanvasCommand {
+  RRectCommand(this.rrect, this.paint);
+  final RRect rrect;
+  final Paint? paint;
+
+  @override
+  bool equals(RRectCommand other) {
+    return eq(rrect, other.rrect) && eq(paint, other.paint);
+  }
+
+  @override
+  String toString() {
+    return 'drawRRect(${repr(rrect)}, ${repr(paint)})';
+  }
+}

--- a/lib/src/canvas_commands/transform_command.dart
+++ b/lib/src/canvas_commands/transform_command.dart
@@ -1,0 +1,31 @@
+import 'dart:typed_data';
+import 'package:vector_math/vector_math_64.dart';
+import 'command.dart';
+
+/// This canvas command describes either a single or multiple method calls
+/// `canvas.translate()`, `canvas.rotate()`, `canvas.scale()`, or
+/// `canvas.transform()`.
+class TransformCommand extends CanvasCommand {
+  TransformCommand() : _transform = Matrix4.identity();
+
+  final Matrix4 _transform;
+
+  void transform(Float64List matrix) {
+    _transform.multiply(Matrix4.fromFloat64List(matrix));
+  }
+
+  void translate(double dx, double dy) => _transform.translate(dx, dy);
+  void rotate(double angle) => _transform.rotateZ(angle);
+  void scale(double sx, double sy) => _transform.scale(sx, sy, 1);
+
+  @override
+  bool equals(TransformCommand other) {
+    return eq(_transform.storage, other._transform.storage);
+  }
+
+  @override
+  String toString() {
+    final content = _transform.storage.map(repr).join(', ');
+    return 'transform($content)';
+  }
+}

--- a/lib/src/mock_canvas.dart
+++ b/lib/src/mock_canvas.dart
@@ -1,0 +1,248 @@
+import 'dart:math';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test/fake.dart';
+
+import 'assertion_mode.dart';
+import 'canvas_commands/cliprect_command.dart';
+import 'canvas_commands/command.dart';
+import 'canvas_commands/image_command.dart';
+import 'canvas_commands/line_command.dart';
+import 'canvas_commands/paragraph_command.dart';
+import 'canvas_commands/rect_command.dart';
+import 'canvas_commands/rrect_command.dart';
+import 'canvas_commands/transform_command.dart';
+
+/// [MockCanvas] is a utility class for writing tests. It supports the same API
+/// as the regular [Canvas] class from dart:ui (in theory; any missing commands
+/// can be added as the need arises). In addition, this class is also a
+/// [Matcher], allowing it to be used in `expect()` calls:
+/// ```dart
+/// final canvas = MockCanvas();
+/// // ... draw something on the canvas
+/// // then check that the commands issued were the ones that you'd expect:
+/// expect(
+///   canvas,
+///   MockCanvas()
+///     ..translate(10, 10)
+///     ..drawRect(const Rect.fromLTWH(0, 0, 100, 100)),
+/// );
+/// ```
+///
+/// Two mock canvases will match only if they have the same number of commands,
+/// and if each pair of corresponding commands matches.
+///
+/// Multiple transform commands (`translate()`, `scale()`, `rotate()` and
+/// `transform()`) that are issued in a row are always joined into a single
+/// combined transform. Thus, for example, calling `translate(10, 10)` and
+/// then `translate(30, -10)` will match a single call `translate(40, 0)`.
+///
+/// Some commands can be partially specified. For example, in `drawLine()` and
+/// `drawRect()` the `paint` argument is optional. If provided, it will be
+/// checked against the actual Paint used, but if omitted, the match will still
+/// succeed.
+///
+/// Commands that involve numeric components (i.e. coordinates, dimensions,
+/// etc) will be matched approximately, with the default absolute tolerance of
+/// 1e-10.
+class MockCanvas extends Fake implements Canvas, Matcher {
+  MockCanvas({this.mode = AssertionMode.matchExactly})
+      : _commands = [],
+        _saveCount = 0;
+
+  final AssertionMode mode;
+  final List<CanvasCommand> _commands;
+  int _saveCount;
+
+  /// The absolute tolerance used when comparing numeric quantities for
+  /// equality. Two numeric variables `x` and `y` are considered equal if they
+  /// are within the distance [tolerance] from each other.
+  ///
+  /// When comparing two [MockCanvas] objects, the largest of their respective
+  /// [tolerance]s is used.
+  double tolerance = 1e-10;
+
+  //#region Matcher API
+
+  @override
+  bool matches(covariant MockCanvas other, Map matchState) {
+    switch (mode) {
+      case AssertionMode.matchExactly:
+        return matchExactly(other, matchState);
+      case AssertionMode.containsAnyOrder:
+        return containsAnyOrder(other, matchState);
+    }
+  }
+
+  @override
+  Description describe(Description description) {
+    description.add('Canvas$_commands');
+    return description;
+  }
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
+    return mismatchDescription.add(matchState['description'] as String);
+  }
+
+  bool matchExactly(covariant MockCanvas other, Map matchState) {
+    if (_saveCount != 0) {
+      return _fail('Canvas finished with saveCount=$_saveCount', matchState);
+    }
+    final n1 = _commands.length;
+    final n2 = other._commands.length;
+    if (n1 != n2) {
+      return _fail(
+        'Canvas contains $n1 commands, but $n2 expected',
+        matchState,
+      );
+    }
+    final useTolerance = max(tolerance, other.tolerance);
+    for (var i = 0; i < n1; i++) {
+      final cmd1 = _commands[i];
+      final cmd2 = other._commands[i];
+      if (cmd1.runtimeType != cmd2.runtimeType) {
+        return _fail(
+          'Mismatched canvas commands at index $i: the actual '
+          'command is ${cmd1.runtimeType}, while the expected '
+          'was ${cmd2.runtimeType}',
+          matchState,
+        );
+      }
+      cmd1.tolerance = useTolerance;
+      if (!cmd1.equals(cmd2)) {
+        return _fail(
+          'Mismatched canvas commands at index $i: the actual '
+          'command is ${cmd1.toString()}, while the expected '
+          'was ${cmd2.toString()}',
+          matchState,
+        );
+      }
+    }
+    return true;
+  }
+
+  bool containsAnyOrder(covariant MockCanvas other, Map matchState) {
+    if (_saveCount != 0) {
+      return _fail('Canvas finished with saveCount=$_saveCount', matchState);
+    }
+    final useTolerance = max(tolerance, other.tolerance);
+    final remainingActualCommands = other._commands.toList();
+    for (final expectedCommand in _commands) {
+      final idx = remainingActualCommands.indexWhere((cmd) {
+        if (expectedCommand.runtimeType != cmd.runtimeType) {
+          return false;
+        }
+
+        expectedCommand.tolerance = cmd.tolerance = useTolerance;
+        return expectedCommand.equals(cmd);
+      });
+      if (idx == -1) {
+        return _fail(
+          'Expected canvas command not found: $expectedCommand. '
+          'Actual commands: $_commands',
+          matchState,
+        );
+      } else {
+        remainingActualCommands.removeAt(idx);
+      }
+    }
+    return true;
+  }
+
+  //#endregion
+
+  //#region Canvas API
+
+  @override
+  void transform(Float64List matrix4) {
+    _lastTransform.transform(matrix4);
+  }
+
+  @override
+  void translate(double dx, double dy) {
+    _lastTransform.translate(dx, dy);
+  }
+
+  @override
+  void rotate(double angle) {
+    _lastTransform.rotate(angle);
+  }
+
+  @override
+  void scale(double sx, [double? sy]) {
+    sy ??= sx;
+    _lastTransform.scale(sx, sy);
+  }
+
+  @override
+  void clipRect(
+    Rect rect, {
+    ClipOp clipOp = ClipOp.intersect,
+    bool doAntiAlias = true,
+  }) {
+    _commands.add(ClipRectCommand(rect, clipOp, doAntiAlias));
+  }
+
+  @override
+  void drawRect(Rect rect, [Paint? paint]) {
+    _commands.add(RectCommand(rect, paint));
+  }
+
+  @override
+  void drawRRect(RRect rrect, [Paint? paint]) {
+    _commands.add(RRectCommand(rrect, paint));
+  }
+
+  @override
+  void drawLine(Offset p1, Offset p2, [Paint? paint]) {
+    _commands.add(LineCommand(p1, p2, paint));
+  }
+
+  @override
+  void drawParagraph(Paragraph? paragraph, Offset offset) {
+    _commands.add(ParagraphCommand(offset));
+  }
+
+  @override
+  void drawImage(Image? image, Offset offset, [Paint? paint]) {
+    // don't compare the actual images as that would be slow, brittle and hard to test
+    _commands.add(ImageCommand(offset, paint));
+  }
+
+  @override
+  int getSaveCount() => _saveCount;
+
+  @override
+  void restore() => _saveCount--;
+
+  @override
+  void save() => _saveCount++;
+
+  //#endregion
+
+  //#region Private helpers
+
+  TransformCommand get _lastTransform {
+    if (_commands.isNotEmpty && _commands.last is TransformCommand) {
+      return _commands.last as TransformCommand;
+    }
+    final transform2d = TransformCommand();
+    _commands.add(transform2d);
+    return transform2d;
+  }
+
+  bool _fail(String reason, Map state) {
+    state['description'] = reason;
+    return false;
+  }
+
+  //#endregion
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: canvas_test_helpers
+description: A package with classes to help testing applications using the canvas
+version: 0.0.1
+homepage: https://pub.dev/packages/canvas_test_helpers
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
+  test: ^1.17.10
+
+dev_dependencies:
+  flutter_lints: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: canvas_test_helpers
 description: A package with classes to help testing applications using the canvas
-version: 0.0.1
+version: 0.1.0
 homepage: https://pub.dev/packages/canvas_test_helpers
 
 environment:


### PR DESCRIPTION
This is the migration of the canvas test helpers that used to live in Flame, but was decided to be taken out and put in its own package.