### PR TITLE
Implement save and restore functions on mock canvas so their effects can be tested

### DIFF
--- a/lib/src/canvas_commands/transform_command.dart
+++ b/lib/src/canvas_commands/transform_command.dart
@@ -6,26 +6,31 @@ import 'command.dart';
 /// `canvas.translate()`, `canvas.rotate()`, `canvas.scale()`, or
 /// `canvas.transform()`.
 class TransformCommand extends CanvasCommand {
-  TransformCommand() : _transform = Matrix4.identity();
+  final Matrix4 matrix;
 
-  final Matrix4 _transform;
+  TransformCommand() : matrix = Matrix4.identity();
+  TransformCommand.from(this.matrix);
 
-  void transform(Float64List matrix) {
-    _transform.multiply(Matrix4.fromFloat64List(matrix));
+  void setFrom(Matrix4 matrix) {
+    this.matrix.setFrom(matrix);
   }
 
-  void translate(double dx, double dy) => _transform.translate(dx, dy);
-  void rotate(double angle) => _transform.rotateZ(angle);
-  void scale(double sx, double sy) => _transform.scale(sx, sy, 1);
+  void transform(Float64List matrix) {
+    this.matrix.multiply(Matrix4.fromFloat64List(matrix));
+  }
+
+  void translate(double dx, double dy) => matrix.translate(dx, dy);
+  void rotate(double angle) => matrix.rotateZ(angle);
+  void scale(double sx, double sy) => matrix.scale(sx, sy, 1);
 
   @override
   bool equals(TransformCommand other) {
-    return eq(_transform.storage, other._transform.storage);
+    return eq(matrix.storage, other.matrix.storage);
   }
 
   @override
   String toString() {
-    final content = _transform.storage.map(repr).join(', ');
+    final content = matrix.storage.map(repr).join(', ');
     return 'transform($content)';
   }
 }


### PR DESCRIPTION
I'm writing a PR on flame to fix an issue I found where components are not properly rendered in priority order if they are HUD.
Since that involves checking if the camera is applied or not, I am modifying this so that not only the save/restore count as number is saved, but the transformations are actually applied.

This has small implications to all our other existing tests, basically because of two things:

1. we always clear up the camera at the end of the render phase, which requires a new assertion for tests using `matchExactly`:
before:
```
 .. camera is set
 .. your render checks
```
after:
```
 .. camera is set
 .. your render checks
 .. camera is cleared
```
2. since we collapse adjacent transform operations, in some camera tests we were not actually rendering any component, and just checking that the camera transform is applied; however due to the collapse and my optimization on the render flow, the camera was no longer applied needlessly, so all camera tests had to be modified to actually have a component (most already had)

---

For the context of how this is used, check https://github.com/flame-engine/flame/pull/1148